### PR TITLE
Fix CORS Middleware

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,8 +17,7 @@ app = FastAPI()
 
 # io = gr.Interface(lambda x: "Hello, " + x + "!", "textbox", "textbox")
 
-def add(app: FastAPI):
-    app.add_middleware(
+app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=True,


### PR DESCRIPTION
CorsMiddleware was not correctly added to the FastAPI App.